### PR TITLE
restored the notion of domain being contextual rather than declared

### DIFF
--- a/src/controllers/status/StatusController.ts
+++ b/src/controllers/status/StatusController.ts
@@ -9,14 +9,14 @@ export class StatusController extends Controller {
     const domain: string = (process.env.SERVER_DOMAIN) as string;
     const serverWallet = Utils.GetDomainInfo(domain)?.wallet;
     const config = Utils.GetConfig();
-    
+
     const statusObj = {
       server: {
         walletAddress: serverWallet?.address,
         publicKey: serverWallet?.publicKey,
-        provider: config.data.provider.name,
-        chainId: config.data.provider.chainId,
-        rpc: config.data.provider.rpc
+        provider: config.activeDomain.provider?.name,
+        chainId: config.activeDomain.provider?.chainId,
+        rpc: config.activeDomain.provider?.rpc
       },
       client: {
         walletAddress: clientCookie?.wallet?.address,
@@ -24,7 +24,7 @@ export class StatusController extends Controller {
       },
       timestamp: new Date().toISOString()
     }
-    
-    this.sendResponse(res, statusObj); 
+
+    this.sendResponse(res, statusObj);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,12 +9,19 @@ import { WriteController } from '@controllers/write/WriteController';
 const app = express();
 const PORT = process.env.PORT || 3000;
 
-// init server-side wallet that reads from HOME/.data-wallet
-const domain: string = (process.env.SERVER_DOMAIN) as string;
-Utils.InitServerWallet(domain);
 
 app.use(express.json());
 app.use(cookieParser());
+
+// attach to the active domain. The domain is declared by context not by the environment
+app.use(async (req, res, next) => {
+  if (req.app.locals.episteryConfig?.domain?.name !== req.hostname) {
+    req.app.locals.episteryConfig = Utils.GetConfig();
+    Utils.InitServerWallet(req.hostname);
+    await app.locals.episteryConfig.loadDomain(req.hostname);
+  }
+  next();
+})
 
 const createController = new CreateController();
 const statusController = new StatusController();

--- a/src/utils/Config.ts
+++ b/src/utils/Config.ts
@@ -10,13 +10,14 @@ export class Config {
   public readonly configFile: string;
   public data!: RootConfig;
   public domains: Record<string, DomainConfig> = {};
+  private _activeDomain: string = "";
 
   constructor() {
     this.rootName = 'data-wallet';
     this.homeDir = (process.platform === 'win32' ? process.env.USERPROFILE : process.env.HOME) || '';
     this.configDir = join(this.homeDir, '.' + this.rootName);
     this.configFile = join(this.configDir, 'config.ini');
-    
+
     if (!fs.existsSync(this.configFile)) {
       this.initialize();
     } else {
@@ -35,26 +36,30 @@ export class Config {
         rpc: chainRpcUrl,
       }
     };
-    
+
     this.data = defaultConfig;
-    
+
     if (!fs.existsSync(this.configDir)) {
       fs.mkdirSync(this.configDir, { recursive: true });
     }
     this.save();
   }
 
+  public get activeDomain() {
+    return this.domains[this._activeDomain];
+  }
   public loadDomain(domain: string): DomainConfig | null {
     try {
+      this._activeDomain = domain;
       if (this.domains[domain]) return this.domains[domain];
-      
+
       const domainConfigDir = join(this.configDir, domain);
       const domainConfigFile = join(domainConfigDir, 'config.ini');
-      
+
       if (!fs.existsSync(domainConfigFile)) {
         return null;
       }
-      
+
       const fileData = fs.readFileSync(domainConfigFile);
       this.domains[domain] = ini.decode(fileData.toString()) as DomainConfig;
       return this.domains[domain];
@@ -67,11 +72,11 @@ export class Config {
   public saveDomain(domain: string, domainConfig: DomainConfig): void {
     const domainConfigDir = join(this.configDir, domain);
     const domainConfigFile = join(domainConfigDir, 'config.ini');
-    
+
     if (!fs.existsSync(domainConfigDir)) {
       fs.mkdirSync(domainConfigDir, { recursive: true });
     }
-    
+
     this.domains[domain] = domainConfig;
     const text = ini.stringify(domainConfig as any);
     fs.writeFileSync(domainConfigFile, text);


### PR DESCRIPTION
I attempted to restore the idea that the epistery module acts for whatever domain is in the request structure. (req.hostname). It complicates the initialization a bit, but simplifies the configuration. In other words, I don't think we want a SERVER_DOMAIN envar (it also wouldn't work with my implementation of [sitewell.net](http://sitewell.net/) which services multiple domains)
Another issue/question which I didn't address is that I had /.epistery delivering the JSON declaring all the addresses, controllers and policies of this server, while .epistery/status is the human version of the same and .epistery/[controller] services all the actual functionality. I could be convinced otherwise.