### PR TITLE
feat: device connect via URL + fix join token for already-authorized rivets

### DIFF
--- a/client/devices.html
+++ b/client/devices.html
@@ -1,0 +1,730 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta name="referrer" content="strict-origin-when-cross-origin">
+  <link rel="icon" href="{{epistery.rootPath}}/favicon.ico">
+  <title>My Collection — {{server.domain}}</title>
+  <script src="{{epistery.rootPath}}/lib/ethers.min.js"></script>
+  <script type="module">
+    import Witness from '{{epistery.rootPath}}/lib/witness.js';
+
+    const rootPath = '{{epistery.rootPath}}';
+    let witness = null;
+
+    window.addEventListener('DOMContentLoaded', async () => {
+      try {
+        witness = await Witness.connect({ rootPath });
+        const wallet = witness.wallet;
+
+        if (!wallet) { showSection('no-wallet'); return; }
+        if (!wallet.contractAddress) {
+          showSection('no-contract');
+          document.getElementById('setup-link').href = `${rootPath}/status`;
+          return;
+        }
+
+        showSection('loading');
+        await loadDevices(wallet);
+      } catch (e) {
+        showSection('error');
+        document.getElementById('error-msg').textContent = e.message;
+      }
+    });
+
+    function showSection(id) {
+      ['loading','no-wallet','no-contract','error','devices'].forEach(s => {
+        const el = document.getElementById('section-' + s);
+        if (el) el.style.display = (s === id) ? '' : 'none';
+      });
+    }
+
+    async function loadDevices(wallet) {
+      const artifactRes = await fetch(`${rootPath}/artifacts/IdentityContract.json`);
+      const artifact = await artifactRes.json();
+
+      const provider = new ethers.providers.JsonRpcProvider('https://polygon-bor-rpc.publicnode.com');
+      const contract = new ethers.Contract(wallet.contractAddress, artifact.abi, provider);
+
+      let addresses = [], names = [];
+      try {
+        const result = await contract.getRivetsWithNames();
+        addresses = result[0];
+        names = result[1];
+      } catch (e) {
+        try {
+          addresses = await contract.getRivets();
+          names = addresses.map(() => '');
+        } catch (e2) {
+          throw new Error('Could not load your collection: ' + e2.message);
+        }
+      }
+
+      renderDevices(addresses, names, wallet);
+      showSection('devices');
+    }
+
+    function guessIcon(name) {
+      const n = (name || '').toLowerCase();
+      if (/epistery|service|recovery/i.test(n)) return '🛡️';
+      if (/iphone|android|phone|mobile/i.test(n)) return '📱';
+      if (/ipad|tablet/i.test(n)) return '📋';
+      if (/mac|macbook|laptop/i.test(n)) return '💻';
+      if (/chrome|firefox|safari|edge|browser/i.test(n)) return '🌐';
+      if (/pc|desktop|windows|linux/i.test(n)) return '🖥️';
+      return '🔐';
+    }
+
+    function renderDevices(addresses, names, wallet) {
+      const currentRivet = (wallet.rivetAddress || wallet.address || '').toLowerCase();
+      const contractAddress = wallet.contractAddress;
+      const list = document.getElementById('device-list');
+      const count = document.getElementById('device-count');
+      const connectUrl = `${window.location.origin}${rootPath}/status?connect=${contractAddress}`;
+
+      list.innerHTML = '';
+      if (count) count.textContent = addresses ? addresses.length : 0;
+
+      if (!addresses || addresses.length === 0) {
+        list.innerHTML = '<p class="muted">No devices in your collection yet.</p>';
+      } else {
+        addresses.forEach((addr, i) => {
+          const name = names[i] || 'Unnamed device';
+          const isThis = addr.toLowerCase() === currentRivet;
+          const isEpistery = /epistery|service|recovery/i.test(name);
+          const icon = isThis ? '🖥️' : guessIcon(name);
+
+          const card = document.createElement('div');
+          card.className = 'device-card' + (isThis ? ' is-this' : '') + (isEpistery ? ' is-service' : '');
+          card.innerHTML = `
+            <span class="device-icon">${icon}</span>
+            <div class="device-info">
+              <div class="device-name">
+                ${escHtml(name)}
+                ${isThis ? '<span class="badge badge-you">You are here</span>' : ''}
+                ${isEpistery ? '<span class="badge badge-service">Recovery service</span>' : ''}
+              </div>
+              <div class="device-addr">${addr.slice(0,8)}…${addr.slice(-6)}</div>
+            </div>
+            <div class="device-actions">
+              ${isThis
+                ? '<span class="trusted-label">Active ✓</span>'
+                : `<button type="button" class="remove-btn" data-addr="${addr}" data-name="${escHtml(name)}" data-epistery="${isEpistery}">Remove</button>`
+              }
+            </div>
+          `;
+          list.appendChild(card);
+        });
+
+        list.querySelectorAll('.remove-btn').forEach(btn => {
+          btn.onclick = () => handleRemove(btn.dataset.addr, btn.dataset.name, contractAddress, btn.dataset.epistery === 'true');
+        });
+      }
+
+      // Set up add-device section
+      const linkInput = document.getElementById('connect-link');
+      const copyBtn = document.getElementById('copy-link-btn');
+      const shareBtn = document.getElementById('share-btn');
+      const qrImg = document.getElementById('qr-img');
+
+      linkInput.value = connectUrl;
+      qrImg.src = `https://api.qrserver.com/v1/create-qr-code/?size=180x180&margin=8&data=${encodeURIComponent(connectUrl)}`;
+      qrImg.alt = 'QR code — scan on your other device';
+
+      copyBtn.onclick = async () => {
+        try {
+          await navigator.clipboard.writeText(connectUrl);
+          copyBtn.textContent = '✅ Copied!';
+          setTimeout(() => { copyBtn.textContent = 'Copy Link'; }, 2500);
+        } catch (_) { linkInput.select(); document.execCommand('copy'); }
+      };
+
+      if (navigator.share) {
+        shareBtn.style.display = '';
+        shareBtn.onclick = () => navigator.share({ title: 'Add this device to my collection', url: connectUrl });
+      }
+    }
+
+    async function handleRemove(addr, name, contractAddress, isEpistery) {
+      const warning = isEpistery
+        ? `Remove Epistery from your collection?\n\nOnce removed, the recovery service will have no access to your data — not now, not ever. You can add it back at any time.`
+        : `Remove "${name}" from your collection?\n\nThat device will lose access to your data. You can add it back any time by opening the invite link on that device again.`;
+
+      if (!confirm(warning)) return;
+
+      const output = document.getElementById('remove-output');
+      output.innerHTML = '<div class="status-loading">Removing from your collection — this takes a few seconds…</div>';
+
+      try {
+        const artifactRes = await fetch(`${rootPath}/artifacts/IdentityContract.json`);
+        const artifact = await artifactRes.json();
+
+        const res = await fetch(`${rootPath}/identity/prepare-remove-rivet`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            signerAddress: witness.wallet.rivetAddress || witness.wallet.address,
+            contractAddress,
+            rivetToRemove: addr
+          })
+        });
+
+        if (!res.ok) throw new Error('prepare-remove not available');
+        const { transaction } = await res.json();
+
+        const provider = new ethers.providers.JsonRpcProvider('https://polygon-bor-rpc.publicnode.com');
+        const rivetWallet = new ethers.Wallet(await witness.wallet.exportPrivateKey(), provider);
+        const tx = await rivetWallet.sendTransaction(transaction);
+        output.innerHTML = '<div class="status-loading">Waiting for confirmation…</div>';
+        await tx.wait();
+
+        output.innerHTML = `<div class="status-success">"${name}" removed from your collection. <a href="">Refresh to update.</a></div>`;
+        await loadDevices(witness.wallet);
+      } catch (e) {
+        if (e.message.includes('prepare-remove')) {
+          output.innerHTML = `<div class="status-info">
+            <strong>Removal coming soon.</strong>
+            For now, go to <a href="${rootPath}/status">Status → Manage Identity</a> to remove a device.
+          </div>`;
+        } else {
+          output.innerHTML = `<div class="status-error">Could not remove: ${escHtml(e.message)}</div>`;
+        }
+      }
+    }
+
+    function escHtml(str) {
+      return String(str).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+    }
+  </script>
+
+  <style>
+    * { box-sizing: border-box; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
+      margin: 0; padding: 0;
+      background: #f4f6f9;
+      color: #222;
+    }
+
+    /* ——— Page header ——— */
+    .page-header {
+      background: #fff;
+      border-bottom: 1px solid #e0e0e0;
+      padding: 28px 32px 22px;
+    }
+    .page-header h1 { margin: 0 0 4px; font-size: 1.7em; font-weight: 700; }
+    .page-header .tagline { margin: 0; color: #555; font-size: 1em; font-style: italic; }
+
+    /* ——— Intro narrative ——— */
+    .intro-card {
+      background: #fff;
+      border-radius: 10px;
+      border: 1px solid #e0e0e0;
+      margin-bottom: 24px;
+      overflow: hidden;
+    }
+
+    .intro-lead {
+      background: linear-gradient(135deg, #e8f4fd 0%, #f0f7ff 100%);
+      border-bottom: 1px solid #cce3f7;
+      padding: 20px 24px;
+      font-size: 1.05em;
+      line-height: 1.65;
+      color: #1a3a5c;
+    }
+
+    .intro-lead strong {
+      font-size: 1.08em;
+    }
+
+    .intro-body {
+      padding: 20px 24px;
+      font-size: 0.93em;
+      color: #444;
+      line-height: 1.7;
+    }
+
+    .intro-body p { margin: 0 0 14px; }
+    .intro-body p:last-child { margin-bottom: 0; }
+
+    .intro-body .highlight {
+      background: #fff8e1;
+      border-left: 3px solid #f5a623;
+      padding: 10px 14px;
+      border-radius: 0 6px 6px 0;
+      margin: 14px 0;
+      font-style: italic;
+      color: #5a3e00;
+    }
+
+    .intro-body a {
+      color: #007bff;
+      text-decoration: none;
+      font-weight: 500;
+    }
+
+    .device-examples {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin: 14px 0;
+    }
+
+    .device-example {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+      background: #f0f4f8;
+      border: 1px solid #dde4ed;
+      border-radius: 20px;
+      padding: 5px 12px;
+      font-size: 0.88em;
+      color: #334;
+    }
+
+    /* ——— Body layout ——— */
+    .page-body {
+      max-width: 660px;
+      margin: 28px auto;
+      padding: 0 16px;
+    }
+
+    /* ——— Cards ——— */
+    .card {
+      background: #fff;
+      border-radius: 10px;
+      border: 1px solid #e0e0e0;
+      margin-bottom: 20px;
+      overflow: hidden;
+    }
+
+    .card-header {
+      padding: 16px 20px 12px;
+      border-bottom: 1px solid #f0f0f0;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .card-header h2 { margin: 0; font-size: 1.05em; font-weight: 600; }
+    .card-header .count {
+      background: #007bff;
+      color: #fff;
+      font-size: 0.75em;
+      font-weight: 700;
+      padding: 2px 8px;
+      border-radius: 12px;
+      margin-left: auto;
+    }
+
+    .card-body { padding: 16px 20px; }
+
+    /* ——— Device list ——— */
+    .device-card {
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      padding: 13px 0;
+      border-bottom: 1px solid #f0f0f0;
+    }
+    .device-card:last-child { border-bottom: none; }
+
+    .device-card.is-this {
+      background: #f0f7ff;
+      margin: 0 -20px;
+      padding: 13px 20px;
+    }
+
+    .device-card.is-service {
+      background: #f9f5ff;
+      margin: 0 -20px;
+      padding: 13px 20px;
+      border-bottom-color: #e8e0f5;
+    }
+
+    .device-icon { font-size: 1.75em; width: 36px; text-align: center; flex-shrink: 0; }
+
+    .device-info { flex: 1; min-width: 0; }
+
+    .device-name {
+      font-weight: 600;
+      font-size: 0.95em;
+      display: flex;
+      align-items: center;
+      gap: 7px;
+      flex-wrap: wrap;
+    }
+
+    .badge {
+      font-size: 0.7em;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: 10px;
+    }
+    .badge-you { background: #007bff; color: #fff; }
+    .badge-service { background: #7c3aed; color: #fff; }
+
+    .device-addr {
+      font-family: monospace;
+      font-size: 0.76em;
+      color: #aaa;
+      margin-top: 2px;
+    }
+
+    .device-actions { flex-shrink: 0; }
+
+    .trusted-label { color: #28a745; font-size: 0.85em; font-weight: 600; }
+
+    .remove-btn {
+      background: none;
+      border: 1px solid #ccc;
+      color: #666;
+      padding: 5px 12px;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 0.82em;
+    }
+    .remove-btn:hover { border-color: #dc3545; color: #dc3545; background: #fff5f5; }
+
+    /* ——— Add device ——— */
+    .add-body { padding: 20px; }
+
+    .add-intro {
+      font-size: 0.92em;
+      color: #444;
+      margin: 0 0 18px;
+      line-height: 1.55;
+    }
+
+    .add-layout {
+      display: flex;
+      gap: 22px;
+      align-items: flex-start;
+      flex-wrap: wrap;
+    }
+
+    .qr-box { flex-shrink: 0; text-align: center; }
+    #qr-img {
+      width: 150px; height: 150px;
+      border: 1px solid #ddd;
+      border-radius: 8px;
+      display: block;
+    }
+    .qr-label { font-size: 0.73em; color: #999; margin-top: 6px; }
+
+    .link-box { flex: 1; min-width: 200px; }
+    .link-box label {
+      display: block;
+      font-size: 0.78em;
+      font-weight: 700;
+      color: #555;
+      margin-bottom: 6px;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    .link-row { display: flex; gap: 8px; }
+    .link-input {
+      flex: 1;
+      padding: 9px 10px;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      font-size: 0.78em;
+      font-family: monospace;
+      background: #f8f9fa;
+      min-width: 0;
+    }
+    .copy-btn {
+      background: #007bff; color: #fff;
+      border: none;
+      padding: 9px 14px;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 0.85em;
+      font-weight: 600;
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+    .copy-btn:hover { background: #0056b3; }
+
+    .share-btn {
+      display: none;
+      width: 100%;
+      background: #28a745; color: #fff;
+      border: none;
+      padding: 10px;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 0.9em;
+      font-weight: 600;
+      margin-top: 10px;
+    }
+    .share-btn:hover { background: #218838; }
+
+    .link-warning {
+      font-size: 0.76em;
+      color: #888;
+      margin-top: 8px;
+      line-height: 1.4;
+    }
+
+    /* ——— Epistery service card ——— */
+    .service-card-body {
+      padding: 16px 20px;
+      font-size: 0.91em;
+      color: #444;
+      line-height: 1.65;
+    }
+    .service-card-body p { margin: 0 0 12px; }
+    .service-card-body p:last-child { margin-bottom: 0; }
+
+    /* ——— Invitations callout ——— */
+    .invitations-callout {
+      background: #f4f0ff;
+      border: 1px solid #d4c5f9;
+      border-radius: 10px;
+      padding: 18px 20px;
+      margin-bottom: 20px;
+      display: flex;
+      gap: 14px;
+      align-items: flex-start;
+    }
+    .invitations-callout .ci { font-size: 1.8em; flex-shrink: 0; }
+    .invitations-callout h3 { margin: 0 0 5px; font-size: 0.97em; color: #5b21b6; }
+    .invitations-callout p { margin: 0; font-size: 0.88em; color: #555; line-height: 1.5; }
+    .invitations-callout a { color: #7c3aed; font-weight: 600; }
+
+    /* ——— State blocks ——— */
+    .state-block {
+      background: #fff;
+      border-radius: 10px;
+      border: 1px solid #e0e0e0;
+      padding: 44px 32px;
+      text-align: center;
+    }
+    .state-block .si { font-size: 2.4em; margin-bottom: 12px; }
+    .state-block h2 { margin: 0 0 10px; font-size: 1.2em; }
+    .state-block p { color: #666; font-size: 0.95em; line-height: 1.5; margin: 0 0 18px; }
+    .state-block a.btn {
+      display: inline-block;
+      background: #007bff; color: #fff;
+      text-decoration: none;
+      padding: 10px 24px;
+      border-radius: 6px;
+      font-weight: 600;
+      font-size: 0.9em;
+    }
+
+    /* ——— Status messages ——— */
+    .status-loading { background:#fff3cd; color:#856404; padding:12px 16px; border-radius:6px; margin:10px 0; }
+    .status-success { background:#d4edda; color:#155724; padding:12px 16px; border-radius:6px; margin:10px 0; }
+    .status-error   { background:#f8d7da; color:#721c24; padding:12px 16px; border-radius:6px; margin:10px 0; }
+    .status-info    { background:#e7f3ff; color:#004085; padding:12px 16px; border-radius:6px; margin:10px 0; }
+
+    .muted { color:#999; font-size:0.9em; margin: 10px 0; }
+
+    .section-hidden { display: none; }
+
+    @media (max-width: 500px) {
+      .page-header { padding: 18px 16px 14px; }
+      .page-body { margin: 16px auto; }
+      .add-layout { flex-direction: column; }
+      .qr-box { width: 100%; }
+      #qr-img { width: 130px; height: 130px; margin: 0 auto; }
+      .device-examples { gap: 6px; }
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Page header -->
+  <div class="page-header">
+    <h1>My Collection</h1>
+    <p class="tagline">Your collection of devices is your identity on {{server.domain}}</p>
+  </div>
+
+  <div class="page-body">
+
+    <!-- Narrative intro — always visible -->
+    <div class="intro-card">
+      <div class="intro-lead">
+        <strong>Your collection of devices is you.</strong>
+        Your phone, your tablet, your home PC, your work PC —
+        each one is a member of your collection.
+        Together they share your keys, share your content, and protect each other.
+      </div>
+      <div class="intro-body">
+
+        <p>
+          <strong>Each browser is treated as its own device</strong> — even when two browsers
+          run on the same machine. Chrome on your PC and Edge on the same PC are two separate
+          devices. Add as many as you use.
+        </p>
+
+        <div class="highlight">
+          The power of your collection is what makes your content easy to use,
+          easy to manage, and easy to recover.
+        </div>
+
+        <p><strong>Examples of devices in a collection:</strong></p>
+        <div class="device-examples">
+          <span class="device-example">🌐 Chrome on your home PC</span>
+          <span class="device-example">🌐 Edge on your home PC</span>
+          <span class="device-example">🌐 Chrome at work</span>
+          <span class="device-example">📱 Safari on your iPhone</span>
+          <span class="device-example">📋 Tablet browser</span>
+          <span class="device-example">🛡️ Epistery recovery</span>
+        </div>
+
+        <p>
+          Your content — your pictures, your conversations, your notes —
+          is encrypted with keys that only your collection holds.
+          No one else can read it. Not even {{server.domain}}.
+        </p>
+
+        <p>
+          If a device is lost or stolen, remove its connection here.
+          It can never access your content again, and everything is still safe on your other connections.
+        </p>
+
+        <p>
+          <strong>Epistery is also in your collection</strong> — as a recovery service, not as an owner.
+          If you're ever down to your last connection, Epistery can help you get back in.
+          Remove it at any time and the service immediately loses all access. Zero.
+        </p>
+      </div>
+    </div>
+
+    <!-- ——— State: Loading ——— -->
+    <div id="section-loading" class="state-block section-hidden">
+      <div class="si">⏳</div>
+      <h2>Loading your collection…</h2>
+      <p>Checking the network for your devices.</p>
+    </div>
+
+    <!-- ——— State: No wallet ——— -->
+    <div id="section-no-wallet" class="state-block section-hidden">
+      <div class="si">🔐</div>
+      <h2>This device isn't set up yet</h2>
+      <p>
+        This browser doesn't have an account on {{server.domain}}.
+        Visit Status to create one, or open the invite link from one of your other devices.
+      </p>
+      <a class="btn" href="{{epistery.rootPath}}/status">Set up this device</a>
+    </div>
+
+    <!-- ——— State: Wallet but no identity contract ——— -->
+    <div id="section-no-contract" class="state-block section-hidden">
+      <div class="si">📋</div>
+      <h2>Your collection isn't set up yet</h2>
+      <p>
+        This device has a wallet but isn't part of a collection yet.
+        Go to Status to finish setting up your identity —
+        once that's done, you can add all your other devices here.
+      </p>
+      <a id="setup-link" class="btn" href="{{epistery.rootPath}}/status">Finish setting up</a>
+    </div>
+
+    <!-- ——— State: Error ——— -->
+    <div id="section-error" class="state-block section-hidden">
+      <div class="si">⚠️</div>
+      <h2>Something went wrong</h2>
+      <p id="error-msg"></p>
+      <a class="btn" href="">Try again</a>
+    </div>
+
+    <!-- ——— State: Devices loaded ——— -->
+    <div id="section-devices" class="section-hidden">
+
+      <!-- Connections list -->
+      <div class="card">
+        <div class="card-header">
+          <span>🔗</span>
+          <h2>Your connections</h2>
+          <span class="count" id="device-count">0</span>
+        </div>
+        <div class="card-body">
+          <div id="device-list"></div>
+          <div id="remove-output"></div>
+        </div>
+      </div>
+
+      <!-- Add a connection -->
+      <div class="card">
+        <div class="card-header">
+          <span>➕</span>
+          <h2>Add a connection to your collection</h2>
+        </div>
+        <div class="add-body">
+          <p class="add-intro">
+            Open this link in any browser you want to add — your phone, your tablet, a different browser on this PC.
+            When it opens, that browser automatically joins your collection and gets access to your content.
+          </p>
+          <div class="add-layout">
+            <div class="qr-box">
+              <img id="qr-img" src="" alt="QR code loading…">
+              <div class="qr-label">Scan on your other device</div>
+            </div>
+            <div class="link-box">
+              <label>Or copy and send this link</label>
+              <div class="link-row">
+                <input id="connect-link" class="link-input" type="text" readonly onclick="this.select()">
+                <button id="copy-link-btn" type="button" class="copy-btn">Copy</button>
+              </div>
+              <button id="share-btn" type="button" class="share-btn">📤 Share to other device</button>
+              <p class="link-warning">
+                ⚠️ This link gives full access to your account.
+                Only open it on <em>your own</em> device — never share it with anyone else.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- About epistery in your collection -->
+      <div class="card">
+        <div class="card-header">
+          <span>🛡️</span>
+          <h2>Epistery in your collection</h2>
+        </div>
+        <div class="service-card-body">
+          <p>
+            {{server.domain}} joins your collection as a <strong>recovery service</strong> —
+            one member among your devices, not a special owner.
+            It uses this access only to help you recover if you lose all your other devices.
+          </p>
+          <p>
+            <strong>You are always in control.</strong>
+            Remove Epistery from your collection at any time using the Remove button above.
+            The moment you do, the service has no access to your keys, your data, or your account — now or ever.
+            You can add it back whenever you choose.
+          </p>
+          <p>
+            Think of it like a trusted locksmith who holds one key to your house.
+            You gave them the key — you can take it back.
+            They can't enter without it.
+          </p>
+        </div>
+      </div>
+
+      <!-- Invitations callout -->
+      <div class="invitations-callout">
+        <span class="ci">👥</span>
+        <div>
+          <h3>Sharing with other people? Use Invitations.</h3>
+          <p>
+            Your collection is just for <em>you</em> — your own devices.
+            To share content with a friend or colleague,
+            use <a href="{{epistery.rootPath}}/status">Invitations</a>.
+            An invitation connects your friend's collection to yours,
+            and only shares the specific information you choose.
+          </p>
+        </div>
+      </div>
+
+    </div><!-- /section-devices -->
+  </div><!-- /page-body -->
+
+</body>
+</html>

--- a/client/status.html
+++ b/client/status.html
@@ -973,10 +973,10 @@
               };
             } else {
               identityStatus.innerHTML = `
-                <h4>📱 Rivet Wallet</h4>
-                <p><strong>Address:</strong> <code>${wallet.address}</code></p>
-                <p><strong>Status:</strong> Not upgraded to Identity Contract</p>
-                <p><i>You can either deploy a new Identity Contract, or join an existing one using a token from another device.</i></p>
+                <h4>📱 This Device</h4>
+                <p><strong>Device Address:</strong> <code>${wallet.address}</code></p>
+                <p><strong>Collection:</strong> Not part of a collection yet</p>
+                <p>Start your collection to connect your other devices, or join an existing collection using an invite code from one of your other devices.</p>
               `;
               deployButton.style.display = 'inline-block';
               generateTokenButton.style.display = 'none';
@@ -1007,10 +1007,9 @@
 
               identityOutput.innerHTML = `
                 <div class="success">
-                  <h4>🎉 Identity Contract Deployed!</h4>
-                  <p><strong>Contract Address:</strong> <code>${contractAddress}</code></p>
-                  <p>Your rivet has been upgraded to a portable identity contract.</p>
-                  <p>You can now generate a join token to add this identity from other devices.</p>
+                  <h4>🎉 Your Collection is Ready!</h4>
+                  <p><strong>Collection Address:</strong> <code>${contractAddress}</code></p>
+                  <p>Your collection has been created. Now use <strong>Add a Device</strong> to connect your phone, tablet, or other browsers.</p>
                 </div>
               `;
             } catch (error) {
@@ -1191,11 +1190,11 @@
                 // Success - show the token
                 identityOutput.innerHTML = `
                   <div class="success">
-                    <h4>✅ Rivet Authorized!</h4>
-                    <p><strong>Target Rivet:</strong> <code>${targetAddress}</code></p>
-                    <p>The rivet has been authorized on the blockchain. Now send this token to the other device:</p>
+                    <h4>✅ Device Added to Your Collection!</h4>
+                    <p><strong>Device Address:</strong> <code>${targetAddress}</code></p>
+                    <p>That device is now authorized. Send this invite code to it so it can finish joining:</p>
                     <textarea readonly style="width: 100%; height: 100px; font-family: monospace; font-size: 0.85em; padding: 10px; margin: 10px 0;">${token}</textarea>
-                    <button onclick="navigator.clipboard.writeText('${token}').then(() => alert('Token copied to clipboard!'))" class="action-button">📋 Copy Token</button>
+                    <button onclick="navigator.clipboard.writeText('${token}').then(() => alert('Invite code copied!'))" class="action-button">📋 Copy Invite Code</button>
                     <p class="info-text">
                       The other device should use "Add Rivet from Token" to accept this invitation.
                       Token expires in 1 hour and can only be used by the target rivet.
@@ -1469,135 +1468,188 @@
       .approval-button { background-color: #9c27b0; color: white; border: none; padding: 12px 24px; border-radius: 5px; cursor: pointer; font-size: 16px; font-weight: bold; margin-top: 10px; }
       .approval-button:hover { background-color: #7b1fa2; }
       .approval-button:disabled { background-color: #6c757d; cursor: not-allowed; }
+
+      /* Dashboard layout */
+      .page-header { background: #fff; border-bottom: 1px solid #e0e0e0; padding: 22px 40px 18px; }
+      .page-header h1 { margin: 0 0 4px; font-size: 1.6em; font-weight: 700; }
+      .page-header .domain-line { margin: 0; color: #555; font-size: 0.97em; }
+      .page-body { max-width: 760px; margin: 28px auto; padding: 0 20px; }
+      .page-body h2 { font-size: 1.15em; margin: 24px 0 8px; color: #222; }
+      .page-body h3 { font-size: 1em; margin: 20px 0 8px; color: #333; }
+      .page-body h4 { font-size: 0.95em; margin: 16px 0 6px; color: #444; }
+      .device-type-note { color: #555; font-size: 0.95em; margin: 0 0 14px; }
+      .dev-tools-summary { cursor: pointer; padding: 14px 18px; background: #e9ecef; border-radius: 6px; font-weight: 600; color: #495057; list-style: none; user-select: none; }
+      .dev-tools-summary:hover { background: #dee2e6; }
+      .dev-tools-body { margin-top: 16px; }
+      .dev-tools-footer { color: #aaa; font-size: 0.8em; margin-top: 20px; }
   </style>
 </head>
 <body>
-    <h1>Epistery Status</h1>
-    
-    <h2>Server Wallet</h2>
-    <div class="wallet-info">
-        <p><strong>Domain:</strong> {{server.domain}}</p>
-        <p><strong>Address:</strong> <span class="address">{{server.walletAddress}}</span></p>
-        <p><strong>Provider:</strong> {{server.provider}}</p>
-        <p><strong>Chain ID:</strong> {{server.chainId}}</p>
-    </div>
-    
-    <h2>Local Client Wallet (Current Default)</h2>
-    <div class="wallet-info">
-        <p><strong>Address:</strong> <span id="local-wallet-address" class="address">Loading...</span></p>
-        <p><strong>Public Key:</strong> <span id="local-wallet-public-key" class="address">Loading...</span></p>
-        <p><strong>Source:</strong> <span id="wallet-source">Loading...</span></p>
+
+  <!-- ═══════════════════════════════════════════
+       PAGE HEADER
+  ═══════════════════════════════════════════ -->
+  <div class="page-header">
+    <h1>My Collection</h1>
+    <p class="domain-line">
+      <strong>{{server.domain}}</strong> — your devices, your keys, your data
+    </p>
+  </div>
+
+  <div class="page-body">
+
+    <!-- ═══════════════════════════════════════════
+         SECTION 1 — YOUR COLLECTION (identity contract, shown first)
+    ═══════════════════════════════════════════ -->
+    <div id="identity-contract-section" class="identity-contract-section" style="display:none;">
+      <h2 style="margin-top:0;">Your Collection of Devices</h2>
+      <p>
+        Your collection connects all your devices — each browser, each phone, each tablet —
+        under one identity. Add any device here and it shares access to all your content.
+        Each browser is treated as its own device, even when two browsers run on the same machine.
+      </p>
+
+      <div id="identity-status" class="identity-status"></div>
+
+      <div class="identity-actions">
+        <button id="deploy-identity-button" class="action-button">🚀 Start My Collection</button>
+        <button id="generate-join-token-button" class="action-button" style="display:none;">➕ Add a Device</button>
+        <button id="accept-join-token-button" class="action-button" style="display:none;">📥 Join with Invite Code</button>
+      </div>
+
+      <div id="join-token-input-section" style="display:none;margin-top:20px;">
+        <p><strong>Paste the invite code from your other device:</strong></p>
+        <input type="text" id="join-token-input" class="write-input" placeholder="Paste invite code here…" />
+        <button id="submit-join-token-button" class="action-button">Join This Collection</button>
+      </div>
+
+      <div id="add-rivet-section" style="display:none;margin-top:20px;">
+        <p><strong>Authorize another device to join your collection:</strong></p>
+        <p><em>Enter that device's address, or the URL of the site where it connected.</em></p>
+        <input type="text" id="rivet-address-input" class="write-input" placeholder="Device address (0x…) or site URL" />
+        <button id="add-rivet-button" class="action-button">Add to My Collection</button>
+      </div>
+
+      <div id="identity-output"></div>
     </div>
 
+    <!-- ═══════════════════════════════════════════
+         SECTION 2 — THIS DEVICE
+    ═══════════════════════════════════════════ -->
+    <h2>This Device</h2>
+    <p class="device-type-note">
+      This is how this browser identifies itself on <strong>{{server.domain}}</strong>.
+      Each browser — Chrome, Edge, Safari, MetaMask — is treated as a separate device.
+    </p>
+    <div class="wallet-info">
+      <p><strong>Device Address:</strong> <span id="local-wallet-address" class="address">Loading…</span></p>
+      <p><strong>Public Key:</strong> <span id="local-wallet-public-key" class="address">Loading…</span></p>
+      <p><strong>Type:</strong> <span id="wallet-source">Loading…</span></p>
+    </div>
+
+    <!-- ═══════════════════════════════════════════
+         SECTION 3 — IDENTITIES IN THIS BROWSER
+    ═══════════════════════════════════════════ -->
     <div class="wallet-management-section">
-        <h2>Wallet Management</h2>
-        <p>Manage multiple wallets for this site. You can add Web3 wallets (MetaMask) or browser wallets, and switch between them.</p>
+      <h2>Identities in This Browser</h2>
+      <p>
+        One browser can hold more than one identity — for example, a personal account and a work account.
+        Switch between them here. The active identity is this device's current member of your collection.
+      </p>
 
-        <div id="wallet-list"></div>
+      <div id="wallet-list"></div>
 
-        <div class="wallet-actions">
-            <button id="add-web3-wallet" class="action-button">Add Web3 Wallet (MetaMask)</button>
-            <button id="add-browser-wallet" class="action-button">Add Browser Wallet</button>
+      <div class="wallet-actions">
+        <button id="add-web3-wallet" class="action-button">Connect MetaMask</button>
+        <button id="add-browser-wallet" class="action-button">Create New Identity</button>
+      </div>
+
+      <div id="wallet-management-output"></div>
+    </div>
+
+    <!-- ═══════════════════════════════════════════
+         SECTION 4 — BACK UP THIS DEVICE
+    ═══════════════════════════════════════════ -->
+    <div id="export-section" class="export-section" style="display:none;">
+      <h2>Back Up This Device</h2>
+      <p>
+        Save a copy of this device's key. If you ever lose access to this browser,
+        you can use this backup to rejoin your collection from a new device.
+      </p>
+      <p class="warning-text">⚠️ Keep your backup secure. Anyone who has it can access your account.</p>
+
+      <div class="export-buttons">
+        <button id="export-button" class="export-button">Download Backup (JSON)</button>
+        <button id="export-privatekey-button" class="export-button">Copy Device Key</button>
+        <button id="export-mnemonic-button" class="export-button">Copy Recovery Phrase</button>
+      </div>
+
+      <div id="export-output"></div>
+    </div>
+
+    <!-- ═══════════════════════════════════════════
+         SECTION 5 — DEVELOPER TOOLS (collapsed)
+    ═══════════════════════════════════════════ -->
+    <details style="margin-top:30px;">
+      <summary class="dev-tools-summary">⚙️ Developer Tools</summary>
+      <div class="dev-tools-body">
+
+        <h3>Write a Signed Event</h3>
+        <div class="write-section">
+          <p>Sign and store a message from this device:</p>
+          <input type="text" id="write-input" class="write-input" placeholder="Enter your message…" />
+          <button id="write-button" class="write-button">Sign &amp; Write</button>
+          <div id="write-output"></div>
         </div>
 
-        <div id="wallet-management-output"></div>
-    </div>
-
-    <div id="identity-contract-section" class="identity-contract-section" style="display: none;">
-        <h2>Identity Contract</h2>
-        <p><i>Upgrade your rivet to a portable identity that works across devices and browsers.</i></p>
-        <p>An Identity Contract lets you bind multiple rivets together into a single, unified identity.</p>
-
-        <div id="identity-status" class="identity-status"></div>
-
-        <div class="identity-actions">
-            <button id="deploy-identity-button" class="action-button">🚀 Deploy Identity Contract</button>
-            <button id="generate-join-token-button" class="action-button" style="display: none;">🔗 Generate Join Token</button>
-            <button id="accept-join-token-button" class="action-button" style="display: none;">📥 Add Rivet from Token</button>
+        <h3>Read Events</h3>
+        <div class="read-section">
+          <p>Read signed events stored for this device:</p>
+          <button id="read-button" class="read-button">Read Events</button>
+          <div id="read-output"></div>
         </div>
 
-        <div id="join-token-input-section" style="display: none; margin-top: 20px;">
-            <p><strong>Enter join token from another device:</strong></p>
-            <input type="text" id="join-token-input" class="write-input" placeholder="Paste join token here..." />
-            <button id="submit-join-token-button" class="action-button">Process Join Token</button>
+        <h3>Transfer Ownership</h3>
+        <div class="transfer-section">
+          <p><strong>⚠️ Warning:</strong> This transfers ownership of your data to another address. This cannot be undone.</p>
+          <input type="text" id="transfer-input" class="transfer-input" placeholder="New owner address (0x…)" />
+          <button id="transfer-button" class="transfer-button">Transfer Ownership</button>
+          <div id="transfer-output"></div>
         </div>
 
-        <div id="add-rivet-section" style="display: none; margin-top: 20px;">
-            <p><strong>Add a rivet address to this identity contract:</strong></p>
-            <p><em>(After another device accepts your join token, paste their rivet address here)</em></p>
-            <input type="text" id="rivet-address-input" class="write-input" placeholder="Paste rivet address (0x...)" />
-            <button id="add-rivet-button" class="action-button">Authorize Rivet</button>
+        <h3>Approval Requests</h3>
+        <div class="approval-section">
+          <h4>Create a Request</h4>
+          <p>Ask another device to review and approve a file:</p>
+          <input type="text" id="approval-approver-input" class="approval-input" placeholder="Approver address (0x…)" />
+          <input type="file" id="approval-file-input" class="approval-input" />
+          <input type="text" id="approval-domain-input" class="approval-input" placeholder="Domain (e.g., localhost)" value="localhost" />
+          <button id="create-approval-button" class="approval-button">Create Request</button>
+          <div id="create-approval-output"></div>
         </div>
 
-        <div id="identity-output"></div>
-    </div>
-
-    <div id="export-section" class="export-section" style="display: none;">
-        <h2>Export Wallet to Web3 Plugin</h2>
-        <p><i>This browser has a wallet unique to you and {{server.domain}}. Transfer this identity
-        to a web3 plugin for security and portability.</i></p>
-        <p>Export your browser wallet keys to import into MetaMask or another Web3 wallet extension.</p>
-        <p class="warning-text">⚠️ Keep your private keys secure. Never share them with anyone!</p>
-
-        <div class="export-buttons">
-            <button id="export-button" class="export-button">Download Keys (JSON)</button>
-            <button id="export-privatekey-button" class="export-button">Copy Private Key</button>
-            <button id="export-mnemonic-button" class="export-button">Copy Recovery Phrase</button>
+        <div class="approval-section" style="margin-top:20px;background:#fff3e0;border:2px solid #ff9800;">
+          <h4>My Requests</h4>
+          <p>Requests you have sent to reviewers:</p>
+          <button id="get-all-requestor-button" class="approval-button" style="background:#ff9800;">Get My Requests</button>
+          <div id="get-all-requestor-output"></div>
         </div>
 
-        <div id="export-output"></div>
-    </div>
+        <div class="approval-section" style="margin-top:20px;background:#e8f5e9;border:2px solid #4caf50;">
+          <h4>Pending Reviews</h4>
+          <p>Requests where you are the reviewer:</p>
+          <button id="get-all-approvals-button" class="approval-button" style="background:#4caf50;">Get Pending Reviews</button>
+          <div id="get-all-approvals-output"></div>
+        </div>
 
-    <h2>Write Event Test</h2>
-    <div class="write-section">
-        <p>Test the Epistery write functionality by entering a message below:</p>
-        <input type="text" id="write-input" class="write-input" placeholder="Enter your message here..." />
-        <button id="write-button" class="write-button">Sign Message (w/AQUA)</button>
-        <div id="write-output"></div>
-    </div>
+        <p class="dev-tools-footer">
+          Service: {{server.domain}} · {{server.walletAddress}} · {{server.provider}} · Chain {{server.chainId}}<br>
+          Generated: {{timestamp}}
+        </p>
 
-    <h2>Read Event Test</h2>
-    <div class="read-section">
-        <p>Read your data from the Agent smart contract and IPFS:</p>
-        <button id="read-button" class="read-button">Read from Contract</button>
-        <div id="read-output"></div>
-    </div>
+      </div>
+    </details>
 
-    <h2>Transfer Ownership Test</h2>
-    <div class="transfer-section">
-        <p><strong>⚠️ Warning:</strong> This operation will transfer ownership of your data to another wallet address. This action cannot be undone.</p>
-        <p>Enter the wallet address of the new owner:</p>
-        <input type="text" id="transfer-input" class="transfer-input" placeholder="0x..." />
-        <button id="transfer-button" class="transfer-button">Transfer Ownership</button>
-        <div id="transfer-output"></div>
-    </div>
-
-    <h2>Request System Test</h2>
-    <div class="approval-section">
-        <h3>Create Request</h3>
-        <p>Request review from another wallet address for a file:</p>
-        <input type="text" id="approval-approver-input" class="approval-input" placeholder="Approver Address (0x...)" />
-        <input type="file" id="approval-file-input" class="approval-input" />
-        <input type="text" id="approval-domain-input" class="approval-input" placeholder="Domain (e.g., localhost)" value="localhost" />
-        <button id="create-approval-button" class="approval-button">Create Request</button>
-        <div id="create-approval-output"></div>
-    </div>
-
-    <div class="approval-section" style="margin-top: 20px; background-color: #fff3e0; border: 2px solid #ff9800;">
-        <h3>Get My Requests</h3>
-        <p>Retrieve all requests you have made to reviewers:</p>
-        <button id="get-all-requestor-button" class="approval-button" style="background-color: #ff9800;">Get My Requests</button>
-        <div id="get-all-requestor-output"></div>
-    </div>
-
-    <div class="approval-section" style="margin-top: 20px; background-color: #e8f5e9; border: 2px solid #4caf50;">
-        <h3>Get Pending Requests</h3>
-        <p>Retrieve all requests where you are the reviewer:</p>
-        <button id="get-all-approvals-button" class="approval-button" style="background-color: #4caf50;">Get Pending Requests</button>
-        <div id="get-all-approvals-output"></div>
-    </div>
-
-    <h2>Timestamp</h2>
-    <p><strong>Generated:</strong> {{timestamp}}</p>
+  </div><!-- /page-body -->
 </body>
 </html>

--- a/client/status.html
+++ b/client/status.html
@@ -890,12 +890,20 @@
             const wallet = witness.wallet;
 
             if (wallet.contractAddress) {
+              const connectUrl = `${window.location.origin}${witness.rootPath || '/.well-known/epistery'}/status?connect=${wallet.contractAddress}`;
               identityStatus.innerHTML = `
                 <h4>✅ Identity Contract Active</h4>
                 <p><strong>Contract Address:</strong> <code>${wallet.contractAddress}</code></p>
                 <p><strong>Rivet Address:</strong> <code>${wallet.rivetAddress || wallet.address}</code></p>
                 <p><strong>Type:</strong> ${wallet.type}</p>
-                <button id="view-rivets-button" class="action-button" style="margin-top: 10px;">👥 View All Rivets</button>
+                <div style="margin-top:12px;padding:10px;background:#e8f5e9;border-radius:4px;border-left:4px solid #28a745;">
+                  <strong>📱 Link a new device</strong> — open this URL on the other device after authorizing its rivet:
+                  <input type="text" readonly value="${connectUrl}"
+                    style="width:100%;padding:6px;font-family:monospace;font-size:0.8em;margin:6px 0;"
+                    onclick="this.select()">
+                  <button onclick="navigator.clipboard.writeText('${connectUrl}').then(()=>alert('Link copied!'))" class="action-button" style="font-size:12px;padding:6px 12px;">📋 Copy Link</button>
+                </div>
+                <button id="view-rivets-button" class="action-button" style="margin-top: 10px;">👥 View All Devices</button>
               `;
               deployButton.style.display = 'none';
               generateTokenButton.style.display = 'inline-block';
@@ -1295,12 +1303,27 @@
               );
 
               if (alreadyAuthorized) {
+                // Already on-chain — skip the blockchain tx and go straight to token
+                identityOutput.innerHTML = '<div class="loading">Rivet already authorized — generating join token...</div>';
+                const contractAddress = witness.wallet.contractAddress || witness.wallet.address;
+                const token = await witness.wallet.generateJoinToken(rivetAddressToAdd, contractAddress, window.ethers);
+                const connectUrl = `${window.location.origin}${witness.rootPath || ''}?connect=${rivetAddressToAdd === rivetAddressToAdd ? contractAddress : contractAddress}`;
+
                 identityOutput.innerHTML = `
-                  <div class="error">
-                    <h4>⚠️ Already Authorized</h4>
-                    <p>Rivet <code>${rivetAddressToAdd}</code> is already authorized on this identity contract.</p>
-                    <p>You can generate a new join token for this rivet without re-authorizing it on the blockchain.</p>
-                    <button onclick="document.getElementById('identity-output').innerHTML = ''" class="action-button" style="background: #666; margin-top: 10px;">Close</button>
+                  <div class="success">
+                    <h4>✅ Already Authorized — Token Generated</h4>
+                    <p><strong>Rivet Address:</strong> <code>${rivetAddressToAdd}</code></p>
+                    <p>This rivet is already on-chain. Send either the token <em>or</em> the connect link to the other device:</p>
+                    <h5 style="margin-top:15px;">Option A — Connect Link (easiest)</h5>
+                    <p>Open this URL on the other device (or scan as QR):</p>
+                    <input type="text" readonly value="${window.location.origin}/.well-known/epistery/status?connect=${contractAddress}"
+                      style="width:100%;padding:8px;font-family:monospace;font-size:0.8em;margin:8px 0;"
+                      onclick="this.select()">
+                    <button onclick="navigator.clipboard.writeText('${window.location.origin}/.well-known/epistery/status?connect=${contractAddress}').then(()=>alert('Link copied!'))" class="action-button">📋 Copy Link</button>
+                    <h5 style="margin-top:15px;">Option B — Join Token</h5>
+                    <textarea readonly style="width:100%;height:80px;font-family:monospace;font-size:0.8em;padding:8px;margin:8px 0;">${token}</textarea>
+                    <button onclick="navigator.clipboard.writeText('${token}').then(()=>alert('Token copied!'))" class="action-button">📋 Copy Token</button>
+                    <p class="info-text">Token expires in 1 hour and is bound to this rivet address only.</p>
                   </div>
                 `;
                 return;

--- a/client/wallet.js
+++ b/client/wallet.js
@@ -933,6 +933,20 @@ export class RivetWallet extends Wallet {
     this.type = "Contract";
     this.lastUpdated = Date.now();
   }
+
+  /**
+   * Switches this rivet to a different identity contract.
+   * Use when the rivet is already bound to one contract but needs to join another.
+   * The caller is responsible for verifying on-chain authorization first.
+   * @param {string} contractAddress - The target identity contract address
+   */
+  switchToContract(contractAddress) {
+    this.rivetAddress = this.rivetAddress || this.address;
+    this.address = contractAddress;
+    this.contractAddress = contractAddress;
+    this.type = "Contract";
+    this.lastUpdated = Date.now();
+  }
 }
 
 // Expose RivetWallet globally for browser access

--- a/client/witness.js
+++ b/client/witness.js
@@ -213,6 +213,19 @@ export default class Witness {
         witness.notabot = new NotabotTracker(witness.wallet);
         console.log("[epistery] Notabot tracker initialized");
       }
+
+      // Handle ?connect=<contractAddress> URL param — device linking via URL/QR
+      if (typeof window !== "undefined" && witness.wallet?.source === "rivet") {
+        const urlParams = new URLSearchParams(window.location.search);
+        const connectParam = urlParams.get("connect");
+        if (connectParam) {
+          try {
+            await witness.handleContractConnect(connectParam);
+          } catch (e) {
+            console.warn("[epistery] connect param handling failed:", e.message);
+          }
+        }
+      }
     } catch (e) {
       console.error("Failed to connect to Epistery server:", e);
       // For unclaimed domains, wallet discovery might succeed even if key exchange fails
@@ -1202,6 +1215,68 @@ export default class Witness {
     localStorage.setItem("epistery", JSON.stringify(storageData));
 
     return true;
+  }
+
+  /**
+   * Handle a ?connect=<contractAddress> URL parameter.
+   * Verifies the current rivet is authorized on the given identity contract,
+   * then links (or switches) the wallet to that contract.
+   *
+   * Phone flow: scan QR from PC → URL loads with ?connect=0x... → auto-links.
+   *
+   * @param {string} contractAddress - The identity contract address (0x... or base64)
+   * @returns {Promise<{linked: boolean, contractAddress: string}>}
+   */
+  async handleContractConnect(contractAddress) {
+    if (!this.wallet || this.wallet.source !== "rivet") return { linked: false };
+
+    // Normalize: accept either raw 0x address or base64-encoded address
+    let addr = contractAddress;
+    if (!addr.startsWith("0x")) {
+      try { addr = atob(contractAddress); } catch (_) { addr = contractAddress; }
+    }
+    if (!/^0x[a-fA-F0-9]{40}$/.test(addr)) {
+      console.warn("[epistery] handleContractConnect: invalid address", addr);
+      return { linked: false };
+    }
+
+    // Already linked to this contract — nothing to do
+    if (this.wallet.contractAddress?.toLowerCase() === addr.toLowerCase()) {
+      return { linked: true, contractAddress: addr, alreadyLinked: true };
+    }
+
+    // Verify authorization on-chain via the server endpoint
+    const rivetAddr = this.wallet.rivetAddress || this.wallet.address;
+    const rootPath = this.rootPath || "";
+    const checkRes = await fetch(
+      `${rootPath}/identity/check?contract=${addr}&rivet=${rivetAddr}`
+    );
+    if (!checkRes.ok) throw new Error("Authorization check failed");
+    const { authorized } = await checkRes.json();
+
+    if (!authorized) {
+      console.warn("[epistery] rivet not authorized on contract", addr);
+      return { linked: false, contractAddress: addr, notAuthorized: true };
+    }
+
+    // Link (or switch) wallet to this contract
+    if (this.wallet.contractAddress) {
+      this.wallet.switchToContract(addr);
+    } else {
+      this.wallet.upgradeToContract(addr);
+    }
+
+    this.save();
+
+    // Remove the ?connect= param from the URL without reload
+    if (typeof window !== "undefined" && window.history?.replaceState) {
+      const url = new URL(window.location.href);
+      url.searchParams.delete("connect");
+      window.history.replaceState({}, "", url.toString());
+    }
+
+    console.log("[epistery] Wallet linked to contract", addr);
+    return { linked: true, contractAddress: addr };
   }
 
   getStatus() {

--- a/routes/identity.mjs
+++ b/routes/identity.mjs
@@ -1,5 +1,10 @@
 import express from "express";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
 import { Epistery } from "../dist/epistery.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * Identity routes - deploy identity contracts and add rivets
@@ -77,6 +82,56 @@ export default function identityRoutes(epistery) {
       res.json(result);
     } catch (error) {
       console.error("Prepare add rivet to contract error:", error);
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  /**
+   * GET /identity/check
+   *
+   * Read-only: checks whether a rivet address is authorized on an identity contract.
+   * Used by the client's handleContractConnect() before linking a wallet.
+   *
+   * Query params:
+   *   contract  - Identity contract address (0x...)
+   *   rivet     - Rivet address to check (0x...)
+   */
+  router.get("/check", async (req, res) => {
+    try {
+      const { contract, rivet } = req.query;
+
+      if (!contract || !rivet) {
+        return res.status(400).json({ error: "Missing contract or rivet param" });
+      }
+
+      if (!/^0x[a-fA-F0-9]{40}$/.test(contract) || !/^0x[a-fA-F0-9]{40}$/.test(rivet)) {
+        return res.status(400).json({ error: "Invalid address format" });
+      }
+
+      const { ethers } = await import("ethers");
+
+      // Use the domain's RPC from config
+      const rpc =
+        epistery.domain?.provider?.rpc ||
+        process.env.CHAIN_RPC_URL ||
+        "https://polygon-bor-rpc.publicnode.com";
+
+      const provider = new ethers.providers.JsonRpcProvider(rpc);
+
+      // Load IdentityContract ABI
+      const artifact = JSON.parse(
+        fs.readFileSync(
+          path.join(__dirname, "../artifacts/contracts/IdentityContract.sol/IdentityContract.json"),
+          "utf8"
+        )
+      );
+
+      const identityContract = new ethers.Contract(contract, artifact.abi, provider);
+      const authorized = await identityContract.isAuthorized(rivet);
+
+      res.json({ authorized, contract, rivet });
+    } catch (error) {
+      console.error("Identity check error:", error);
       res.status(500).json({ error: error.message });
     }
   });

--- a/routes/status.mjs
+++ b/routes/status.mjs
@@ -152,5 +152,22 @@ export default function statusRoutes(epistery) {
     res.send(template);
   });
 
+  // Devices page - /devices
+  router.get("/devices", (req, res) => {
+    const domain = req.hostname;
+    const rootPath = req.baseUrl;
+
+    const templatePath = path.resolve(rootDir, "client/devices.html");
+    if (!fs.existsSync(templatePath)) {
+      return res.status(404).send("Devices template not found");
+    }
+
+    let template = fs.readFileSync(templatePath, "utf8");
+    template = template.replace(/\{\{server\.domain\}\}/g, domain);
+    template = template.replace(/\{\{epistery\.rootPath\}\}/g, rootPath);
+
+    res.send(template);
+  });
+
   return router;
 }


### PR DESCRIPTION
## Summary

### Bug fixes
- **Fix**: `status.html` — when a rivet is already authorized on-chain, the "Add Device" flow previously dead-ended. Now generates the invite code and connect link even when the on-chain step is skipped.

### New: Connect URL device linking
A device whose rivet is already authorized on an identity contract can join by opening `?connect=<contractAddress>` in its browser. No token paste, no Mongo lookup needed — completely bypasses the scanner bug where externally-minted contracts don't appear in Mongo.
- `witness.js`: `handleContractConnect()` verifies auth on-chain, then calls `upgradeToContract()` or `switchToContract()` and saves. Strips `?connect=` param after linking.
- `routes/identity.mjs`: new `GET /identity/check?contract=&rivet=` — read-only on-chain authorization check.
- `wallet.js`: new `switchToContract()` — like `upgradeToContract()` but without the "already using" guard (needed when a rivet is bound to the wrong contract).

### New: `client/devices.html` — My Collection page
Served at `/.well-known/epistery/devices`. Consumer-facing dashboard for managing the collection of devices.

**Language model:**
- "Collection of devices" = the identity contract (IdentityContract on-chain)
- "Device" = any rivet — browser, phone, tablet, desktop app, or AI agent
- Each browser is its own device even on the same machine (Chrome ≠ Edge on same PC)
- Epistery appears as a "recovery service" member, not a special owner
- Agents (V6 Secret Service Agent, desktop app) plug in identically — same `addRivet` flow, shown with 🤖 icon

**Features:**
- Lists all devices in the collection via `getRivetsWithNames()`
- "You are here" badge on current device
- QR code + copy link + mobile share for adding a new device
- Remove flow (calls `prepare-remove-rivet` endpoint, falls back to Status page gracefully)
- Callout: "Sharing with others? Use Invitations." — explicitly distinguishes collection members (you) from shared access (others)

### Reworked: `status.html` → My Collection dashboard
- Renamed "Epistery Status" → "My Collection"
- Identity contract section moved to top — it's the primary content, not an advanced section
- Language updated throughout: "rivet" → "device", "identity contract" → "collection", "join token" → "invite code", "deploy" → "Start My Collection"
- Wallet management renamed "Identities in This Browser" with explanation that each browser identity is a separate device
- Export renamed "Back Up This Device" — framed around recovery, not Web3 export
- Write/Read/Transfer/Approval sections collapsed into `<details>Developer Tools</details>`

**Architecture note — future:** The V6 desktop app already joins the collection as a rivet (RootzServiceKey, TPM-rooted). A V6 Secret Service Agent (always-on server process) plugs in identically — it generates a rivet at deploy time, user authorizes it once via the collection, and it has bounded revocable access 24/7. The `devices.html` page already renders it correctly; provisioning UX is future work.

**What Michael needs to add in epistery-host (one change):**
Add "My Collection" nav item pointing to `/.well-known/epistery/devices`.

## Security
- `switchToContract()` does not touch encryption, IndexedDB, or private key material.
- `/identity/check` is read-only (no signing, no writes).
- `handleContractConnect()` verifies on-chain authorization before linking.
- Remove flow requires server-side `prepare-remove-rivet` endpoint (not yet implemented — falls back gracefully with a link to Status page).

## Test plan
- [ ] Status page shows "My Collection" header, identity section first
- [ ] `/.well-known/epistery/devices` loads and shows intro narrative
- [ ] PC with active contract: devices page lists rivets, shows "You are here" badge
- [ ] PC: "Add a Device" shows QR + copy link
- [ ] Phone: open `?connect=<contractAddress>` — wallet links, param cleared
- [ ] Phone with wrong contract: `switchToContract` updates without error
- [ ] `/identity/check` returns `{ authorized: true/false }`
- [ ] Developer Tools section is collapsed by default
- [ ] Epistery service member shows 🛡️ badge

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
