### PR TITLE
fix: stop flipping wallet.address to the contract on upgrade

### DIFF
--- a/client/wallet.js
+++ b/client/wallet.js
@@ -12,11 +12,13 @@
 //   - identityAddress : the canonical identity. Derived: contractAddress
 //                       || signerAddress. Never persisted; always computed.
 //
-// `address` is retained as a per-wallet field for storage compatibility,
-// but is no longer the source of identity decisions — use the getters.
-// (Phase 1b: rename the persistence shape so the storage key matches the
-// vocabulary; until then RivetWallet.upgradeToContract still flips
-// `address` to the contract for backwards-compatible callers.)
+// `address` is the rivet (device key) for the LIFE of the wallet — it is no
+// longer flipped to the contract on upgrade. Identity decisions use the
+// getters (signerAddress / identityAddress) or the explicit contractAddress
+// field. Legacy records that were flipped before this change are un-flipped
+// on load (see RivetWallet.fromJSON migration).
+// (Phase 1b — future: rename the persisted `address` key to `rivetAddress`
+// so the storage shape matches the vocabulary.)
 export class Wallet {
   constructor() {
     this.address = null;
@@ -305,6 +307,21 @@ export class RivetWallet extends Wallet {
     wallet.contractAddress = data.contractAddress;
     wallet.rivetAddress = data.rivetAddress;
     wallet.associations = data.associations || [];
+
+    // Migrate legacy flipped records. Before we stopped flipping, upgradeToContract
+    // set `address = contractAddress` and stashed the rivet on rivetAddress. Restore
+    // `address` to the rivet so it's always the device key. Unambiguous: only an old
+    // flipped record has address === contractAddress with a distinct rivetAddress.
+    // New (unflipped) records have address === rivetAddress !== contractAddress and
+    // are left untouched. Re-saving the wallet persists the corrected shape.
+    if (
+      wallet.contractAddress &&
+      wallet.rivetAddress &&
+      wallet.address &&
+      wallet.address.toLowerCase() === wallet.contractAddress.toLowerCase()
+    ) {
+      wallet.address = wallet.rivetAddress;
+    }
 
     return wallet;
   }
@@ -1002,8 +1019,14 @@ export class RivetWallet extends Wallet {
       throw new Error("Rivet is already using an identity contract");
     }
 
-    this.rivetAddress = this.address; // Save original rivet address
-    this.address = contractAddress; // Present contract address
+    // Do NOT flip `address` to the contract. `address` stays the rivet (device
+    // key) for the life of the wallet; the contract is a separate fact exposed
+    // via contractAddress / identityAddress. Flipping used to make the device
+    // wallet masquerade as its contract — the device list then showed the
+    // contract address, and every consumer that read `address` expecting the
+    // signer was wrong. rivetAddress is kept set (== address) for the
+    // signerAddress getter and a stable persisted shape.
+    this.rivetAddress = this.address;
     this.contractAddress = contractAddress;
     this.type = "Contract";
     this.lastUpdated = Date.now();

--- a/client/witness.js
+++ b/client/witness.js
@@ -10,7 +10,7 @@ import {
   Web3Wallet,
   RivetWallet,
   FidoWallet,
-} from "./wallet.js?v=8";
+} from "./wallet.js?v=9";
 
 // Global ethers variable - will be loaded dynamically if needed
 let ethers;

--- a/client/witness.js
+++ b/client/witness.js
@@ -591,15 +591,29 @@ export default class Witness {
   getWallets() {
     const storageData = this.loadStorageData();
     return {
-      wallets: storageData.wallets.map((w) => ({
-        id: w.id,
-        address: w.wallet.address,
-        source: w.wallet.source,
-        label: w.label,
-        createdAt: w.createdAt,
-        lastUsed: w.lastUsed,
-        isDefault: w.id === storageData.defaultWalletId,
-      })),
+      wallets: storageData.wallets.map((w) => {
+        // Derive the three-fact shape from RAW storage so it's correct even
+        // for legacy records that fromJSON hasn't un-flipped yet (getWallets
+        // reads storage directly, not via fromJSON). signerAddress is always
+        // the rivet; identityAddress is the contract when bound.
+        const rivet = w.wallet.rivetAddress || w.wallet.address;
+        const contract = w.wallet.contractAddress || null;
+        return {
+          id: w.id,
+          // `address` kept for back-compat; may be the contract on an
+          // un-migrated legacy record. Render rivetAddress/signerAddress.
+          address: w.wallet.address,
+          rivetAddress: rivet,
+          signerAddress: rivet,
+          contractAddress: contract,
+          identityAddress: contract || rivet,
+          source: w.wallet.source,
+          label: w.label,
+          createdAt: w.createdAt,
+          lastUsed: w.lastUsed,
+          isDefault: w.id === storageData.defaultWalletId,
+        };
+      }),
       defaultWalletId: storageData.defaultWalletId,
     };
   }
@@ -788,8 +802,11 @@ export default class Witness {
 
     return {
       id: localRivet.id,
-      address: localRivet.address,         // = contract
-      rivetAddress: localRivet.rivetAddress,
+      // `address` no longer flips to the contract on upgrade; expose the
+      // canonical identity explicitly so callers that want the contract keep
+      // getting it, and the rivet stays available separately.
+      address: localRivet.identityAddress,   // = contract once joined
+      rivetAddress: localRivet.signerAddress,
       source: localRivet.source,
       label: localRivet.label,
       identityName: identityName || null,


### PR DESCRIPTION
## Why
`RivetWallet.upgradeToContract` set `this.address = contractAddress`, making the device wallet masquerade as its IdentityContract. The rivet was preserved on `rivetAddress` so the `signerAddress`/`identityAddress` getters still worked — but anything reading `.address` directly (notably `getWallets()`) reported the **contract**. That's why the app's "This device" list showed the contract address, identical to the Active-identity card, and per-wallet identity lookups queried the contract instead of the rivet.

The clean model (getters + explicit `contractAddress`) already existed; the flip was overriding it. This finishes that refactor.

## Changes
- **`wallet.js` `upgradeToContract`** — no longer reassigns `address`; it stays the rivet (device key) for the wallet's life. Only `contractAddress`/`type` change.
- **`wallet.js` `RivetWallet.fromJSON`** — migrate legacy flipped records: when `address === contractAddress` with a distinct `rivetAddress`, restore `address = rivetAddress`. Unambiguous; new (unflipped) records are untouched. Re-saving persists the corrected shape.
- **`witness.js` `getWallets()`** — expose the three-fact shape (`rivetAddress`, `signerAddress`, `contractAddress`, `identityAddress`) derived from **raw** storage, so it's correct even for records `fromJSON` hasn't un-flipped yet. `address` retained for back-compat.
- **`witness.js` join-flow return** — return `identityAddress` explicitly (= contract once joined) instead of relying on the `address` flip; rivet returned separately.

## Risk / compat
- No storage rewrite required for correctness — `getWallets` derives signer/identity from `rivetAddress || address`, so legacy and new records both render right; persisted records self-correct on next save.
- Migration only triggers on the unambiguous `address === contractAddress` case.
- Audited every other `.address` reader in `witness.js`: all are pre-upgrade, freshly-created wallets, logs, or unused returns — only the join return depended on the flip (fixed here).

## Pairs with
`epistery/app` PR for the wallet-list render (shows `signerAddress`). App falls back to `w.address` if this isn't deployed yet, so order is flexible.

Served client libs (`/lib/wallet.js`, `/lib/witness.js`) are cached by browsers — bump + hard-reload after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)